### PR TITLE
fix: prevent Firebase Realtime Database URL parse error on build

### DIFF
--- a/src/domains/auth/services/firebaseClient.ts
+++ b/src/domains/auth/services/firebaseClient.ts
@@ -55,7 +55,7 @@ const app = !getApps().length ? initializeApp(firebaseConfig) : getApps()[0];
 // Serviços Firebase
 // ----------------------------------------------------
 export const auth = getAuth(app);
-export const database = getDatabase(app); // Realtime Database (legacy)
+export const database = firebaseConfig.databaseURL ? getDatabase(app) : null; // Realtime Database (legacy)
 export const firestore = getFirestore(app); // Firestore (novo!)
 export const analytics = typeof window !== "undefined" ? getAnalytics(app) : null;
 

--- a/src/services/firebase/ContentPageService.server.ts
+++ b/src/services/firebase/ContentPageService.server.ts
@@ -1,16 +1,4 @@
-// WORKAROUND: Usando Client SDK até resolver credenciais Admin
-// import { firestore } from '@/domains/auth/services/firebaseAdmin';
-import { firestore } from '@/domains/auth/services/firebaseClient';
-import {
-  collection,
-  query,
-  where,
-  getDocs,
-  orderBy,
-  limit,
-  getDoc,
-  doc,
-} from 'firebase/firestore';
+import { firestore } from '@/domains/auth/services/firebaseAdmin';
 import { CMSPage } from '@/types/cms-types';
 
 /**
@@ -28,40 +16,20 @@ class ContentPageServerService {
    */
   async getBySlug(slug: string): Promise<CMSPage | null> {
     try {
-      console.log(`🔥 [SERVER] Buscando página com slug: "${slug}"`);
-
-      const q = query(
-        collection(firestore, this.collectionName),
-        where('slug', '==', slug),
-        limit(1)
-      );
-
-      const snapshot = await getDocs(q);
+      const snapshot = await firestore
+        .collection(this.collectionName)
+        .where('slug', '==', slug)
+        .limit(1)
+        .get();
 
       if (snapshot.empty) {
-        console.log(`❌ [SERVER] Nenhuma página encontrada com slug: "${slug}"`);
         return null;
       }
 
       const docSnap = snapshot.docs[0];
-      const data = docSnap.data() as Omit<CMSPage, 'id'>;
-
-      const page: CMSPage = {
-        id: docSnap.id,
-        ...data,
-      };
-
-      console.log(`✅ [SERVER] Página encontrada:`, {
-        id: page.id,
-        slug: page.slug,
-        title: page.title,
-        is_published: page.is_published,
-        blocks: page.blocks?.length || 0,
-      });
-
-      return page;
+      return { id: docSnap.id, ...docSnap.data() } as CMSPage;
     } catch (error) {
-      console.error(`❌ [SERVER] Erro ao buscar página:`, error);
+      console.error(`Erro ao buscar página com slug "${slug}":`, error);
       return null;
     }
   }
@@ -72,13 +40,11 @@ class ContentPageServerService {
    */
   async listPublished(): Promise<CMSPage[]> {
     try {
-      const q = query(
-        collection(firestore, this.collectionName),
-        where('is_published', '==', true),
-        orderBy('created_at', 'desc')
-      );
-
-      const snapshot = await getDocs(q);
+      const snapshot = await firestore
+        .collection(this.collectionName)
+        .where('is_published', '==', true)
+        .orderBy('created_at', 'desc')
+        .get();
 
       return snapshot.docs.map(docSnap => ({
         id: docSnap.id,
@@ -97,17 +63,16 @@ class ContentPageServerService {
    */
   async getById(pageId: string): Promise<CMSPage | null> {
     try {
-      const docRef = doc(firestore, this.collectionName, pageId);
-      const docSnap = await getDoc(docRef);
+      const docSnap = await firestore
+        .collection(this.collectionName)
+        .doc(pageId)
+        .get();
 
-      if (!docSnap.exists()) {
+      if (!docSnap.exists) {
         return null;
       }
 
-      return {
-        id: docSnap.id,
-        ...docSnap.data(),
-      } as CMSPage;
+      return { id: docSnap.id, ...docSnap.data() } as CMSPage;
     } catch (error) {
       console.error('Erro ao buscar página por ID:', error);
       return null;


### PR DESCRIPTION
Guard getDatabase() in firebaseClient.ts so it only initializes when
NEXT_PUBLIC_FIREBASE_DATABASE_URL is set, preventing a fatal crash when
the env var is missing in the Vercel dev environment.

Also migrates ContentPageService.server.ts from the client SDK to the
Admin SDK (firebaseAdmin.ts), which is the correct approach for Server
Components and eliminates the transitive import of the problematic
client initialization.

https://claude.ai/code/session_01YbajPij38dS6xK3K9prcLG